### PR TITLE
Update README.md - do not bind method on render

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ class CardIOExample extends Component {
     CardIOUtilities.preload();
   }
 
-  didScanCard(card) {
+  didScanCard = (card) => {
     // the scanned card
   }
 
@@ -41,7 +41,7 @@ class CardIOExample extends Component {
     return (
       <View>
         <CardIOView
-          didScanCard={this.didScanCard.bind(this)}
+          didScanCard={this.didScanCard}
           style={{ flex: 1 }}
         />
       </View>


### PR DESCRIPTION
Use arrow function instead, because `this.didScanCard.bind(this)` will create a new function on every render