### PR TITLE
Android: Fix for  #32 - Exception thrown when starting CardIO Activity

### DIFF
--- a/android/src/main/java/com/cardio/RNCardIOModule.java
+++ b/android/src/main/java/com/cardio/RNCardIOModule.java
@@ -18,7 +18,7 @@ import io.card.payment.CreditCard;
 
 public class RNCardIOModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 
-  public static final int CARD_IO_SCAN = 49463195;
+  public static final int CARD_IO_SCAN = 1;
 
   private Promise promise;
 


### PR DESCRIPTION
Changed request code used to start CardIO activity to be less than 65535