### PR TITLE
Remove createJSModules method from RNCardIOPackage.java

### DIFF
--- a/android/src/main/java/com/cardio/RNCardIOPackage.java
+++ b/android/src/main/java/com/cardio/RNCardIOPackage.java
@@ -21,11 +21,6 @@ public class RNCardIOPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
This error is related to the following breaking change
in react native: https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8