### PR TITLE
Re-add createJSModules() for RN backward-compatibility

### DIFF
--- a/android/src/main/java/com/cardio/RNCardIOPackage.java
+++ b/android/src/main/java/com/cardio/RNCardIOPackage.java
@@ -24,4 +24,9 @@ public class RNCardIOPackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }
+    
+    // For backward-compatibility with RN <0.47.0
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
See [comments](https://github.com/Kerumen/react-native-awesome-card-io/commit/56f65e3f592c07903c1d9d287c0fc2e84634835b#commitcomment-23638444) on 56f65e3