### PR TITLE
Tell RN to set up on main queue to suppress warning

### DIFF
--- a/ios/RCTCardIOUtilities.m
+++ b/ios/RCTCardIOUtilities.m
@@ -19,6 +19,11 @@ RCT_EXPORT_MODULE();
     };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(preload) {
     return [CardIOUtilities preload];
 }


### PR DESCRIPTION
This would suppress the following warning.

> Module RCTCardIOUtilities requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

ref: https://github.com/wix/react-native-navigation/issues/1982