### PR TITLE
Give developers more control over permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ This component provides an abstraction of the card.io entry points for iOS and A
 | `CardIOModule` | [`CardIOPaymentViewController`](https://github.com/card-io/card.io-iOS-SDK#integrate-as-a-view) | [`CardIOActivity`](http://card-io.github.io/card.io-Android-SDK/io/card/payment/CardIOActivity.html) | A module to launch the card.io view controller which handles everything.            |
 | `CardIOView`   | [`CardIOView`](https://github.com/card-io/card.io-iOS-SDK#integrate-as-a-view-controller)       | N / A                                                                                                | Create a `CardIOView` to do card scanning only and manage everything else yourself. |
 
+Note for Android: add 
+
+```<uses-permission android:name="android.permission.CAMERA"/> ```
+
+to your app's `AndroidManifest.xml`
+
+or follow this [`guide for handling Android permissions in React-Native`](https://facebook.github.io/react-native/docs/permissionsandroid)
+
 ### `CardIOView`
 
 *This component is iOS-only as the card.io Android SDK does not offer this functionality.*

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
           package="com.cardio">
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
     <uses-feature android:name="android.hardware.camera.flash" android:required="false" />


### PR DESCRIPTION
Currently permissions in Android are granted in the package manifest file.
This stops developers from prompting for permission to use the camera in the application only when the user is using the feature.
This change will enable developers to stop the camera permission being asked for on initial install.

<img width="405" alt="screen shot 2018-07-18 at 11 41 04" src="https://user-images.githubusercontent.com/9286660/42876933-163058da-8a80-11e8-8a2c-269689abe4ed.png">
