### PR TITLE
Fix 'aapt2 not found' by moving Google Maven repository up

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,11 +6,11 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'


### PR DESCRIPTION
Fixes #112 