### PR TITLE
Add podspec to enable linking through CocoaPods

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint *.js --fix",
     "prettier": "prettier --write *.js"
   },
+  "homepage": "https://github.com/Kerumen/react-native-awesome-card-io",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kerumen/react-native-awesome-card-io"

--- a/react-native-awesome-card-io.podspec
+++ b/react-native-awesome-card-io.podspec
@@ -1,0 +1,19 @@
+require 'json'
+package_json = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+
+  s.name           = "react-native-awesome-card-io"
+  s.version        = package_json["version"]
+  s.summary        = package_json["description"]
+  s.homepage       = package_json["homepage"]
+  s.license        = package_json["license"]
+  s.author         = package_json["author"]
+  s.platform       = :ios, "7.0"
+  s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "v#{s.version}" }
+  s.source_files   = 'ios/*.{h,m}'
+
+  s.dependency 'React'
+  s.dependency 'CardIO', '5.4.1'
+
+end


### PR DESCRIPTION
Those ejecting Expo are using Cocoapods by default and are not really good native developers so supporting Cocoapods out of the box will be helpful for them.

Note I tested this on a freshly ejected Expo SDK31 project and the ios linking went fine and the project can build/start.
No more missing React header problem thanks to the explicit dependency on React


Should fix:
- https://github.com/Kerumen/react-native-awesome-card-io/issues/116 
- https://github.com/Kerumen/react-native-awesome-card-io/issues/114

