### PR TITLE
Avoiding to call to CardIOActivity.canReadCardWithCamera() on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ An object with the following keys:
 
 #### Methods
 
+`canReadCardWithCamera()` -> Boolean
+   
+Determine whether this device supports camera-based card scanning. ([iOS](https://github.com/card-io/card.io-iOS-SDK/blob/ec9a8632c9fd879537354d4b9075aa487dcebe8b/CardIO/CardIOUtilities.h#L24) / [Android](http://card-io.github.io/card.io-Android-SDK/io/card/payment/CardIOActivity.html#canReadCardWithCamera--))
+
 `preload` -> void (iOS only) - The preload method prepares card.io to launch faster. ([iOS](https://github.com/card-io/card.io-iOS-SDK/blob/ec9a8632c9fd879537354d4b9075aa487dcebe8b/CardIO/CardIOUtilities.h#L31))
 
 #### Constants
-
-`CAN_READ_CARD_WITH_CAMERA`: Boolean
-   
-Determine whether this device supports camera-based card scanning. ([iOS](https://github.com/card-io/card.io-iOS-SDK/blob/ec9a8632c9fd879537354d4b9075aa487dcebe8b/CardIO/CardIOUtilities.h#L24) / [Android](http://card-io.github.io/card.io-Android-SDK/io/card/payment/CardIOActivity.html#canReadCardWithCamera--))
 
 `DETECTION_MODE`: String
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,7 @@ An object with the following keys:
 
 #### Methods
 
-`canReadCardWithCamera()` -> Boolean
-   
-Determine whether this device supports camera-based card scanning. ([iOS](https://github.com/card-io/card.io-iOS-SDK/blob/ec9a8632c9fd879537354d4b9075aa487dcebe8b/CardIO/CardIOUtilities.h#L24) / [Android](http://card-io.github.io/card.io-Android-SDK/io/card/payment/CardIOActivity.html#canReadCardWithCamera--))
+`canReadCardWithCamera()` -> Boolean - Determine whether this device supports camera-based card scanning. ([iOS](https://github.com/card-io/card.io-iOS-SDK/blob/ec9a8632c9fd879537354d4b9075aa487dcebe8b/CardIO/CardIOUtilities.h#L24) / [Android](http://card-io.github.io/card.io-Android-SDK/io/card/payment/CardIOActivity.html#canReadCardWithCamera--))
 
 `preload` -> void (iOS only) - The preload method prepares card.io to launch faster. ([iOS](https://github.com/card-io/card.io-iOS-SDK/blob/ec9a8632c9fd879537354d4b9075aa487dcebe8b/CardIO/CardIOUtilities.h#L31))
 

--- a/android/src/main/java/com/cardio/RNCardIOUtilities.java
+++ b/android/src/main/java/com/cardio/RNCardIOUtilities.java
@@ -1,7 +1,12 @@
 package com.cardio;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.IllegalViewOperationException;
 
 import io.card.payment.CardIOActivity;
 
@@ -18,10 +23,12 @@ public class RNCardIOUtilities extends ReactContextBaseJavaModule {
     return "RCTCardIOUtilities";
   }
 
-  @Override
-  public Map<String, Object> getConstants() {
-    final Map<String, Object> constants = new HashMap<>();
-    constants.put("CAN_READ_CARD_WITH_CAMERA", CardIOActivity.canReadCardWithCamera());
-    return constants;
+  @ReactMethod
+  public void canReadCardWithCamera(Promise promise) {
+    try {
+      promise.resolve(CardIOActivity.canReadCardWithCamera());
+    } catch (Exception e) {
+      promise.reject(e);
+    }
   }
 }

--- a/ios/RCTCardIOUtilities.m
+++ b/ios/RCTCardIOUtilities.m
@@ -14,8 +14,7 @@ RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport {
     return @{
-        @"DETECTION_MODE": DETECTION_MODE,
-        @"CAN_READ_CARD_WITH_CAMERA": @([CardIOUtilities canReadCardWithCamera])
+        @"DETECTION_MODE": DETECTION_MODE
     };
 }
 
@@ -26,6 +25,10 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(preload) {
     return [CardIOUtilities preload];
+}
+
+RCT_REMAP_METHOD(canReadCardWithCamera, canReadCardWithCameraResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(@([CardIOUtilities canReadCardWithCamera]));
 }
 
 @end


### PR DESCRIPTION
As some of us know, App Permission Monitor (by Samsung) detects if an app uses some permissions in background and alerts about them.

When an app that uses react-native-awesome-card-io receives a push notification, constant _CAN_READ_CARD_WITH_CAMERA_ is filled by _CardIOActivity.canReadCardWithCamera()_ function. At that moment, App Permission Monitor launches an alert indicating "YOUR-APP has been detected using Camera".

To avoid that alert, I have removed that constant and created a function that calls _CardIOActivity.canReadCardWithCamera()_.