### PR TITLE
Implement missing `scanned` functionality for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ An object with the following keys:
 - `expiryYear` _number_ - Expiry year (may be 0 if expiry information was not requested).
 - `cvv` _string_ - Security code.
 - `postalCode` _string_ - Postal code. Format is country dependent.
-- `scanned` _boolean_ (iOS only) - Was the card number scanned (as opposed to entered manually)?
+- `scanned` _boolean_ - Was the card number scanned (as opposed to entered manually)?
 - `cardholderName` _string_ - Card holder name.
 
 ### CardIOUtilities

--- a/android/src/main/java/com/cardio/RNCardIOModule.java
+++ b/android/src/main/java/com/cardio/RNCardIOModule.java
@@ -97,6 +97,8 @@ public class RNCardIOModule extends ReactContextBaseJavaModule implements Activi
     if (config.hasKey("usePaypalActionbarIcon")) {
       intent.putExtra(CardIOActivity.EXTRA_USE_PAYPAL_ACTIONBAR_ICON, config.getBoolean("usePaypalActionbarIcon"));
     }
+
+    intent.putExtra(CardIOActivity.EXTRA_RETURN_CARD_IMAGE, true);
   }
 
   @Override
@@ -116,6 +118,7 @@ public class RNCardIOModule extends ReactContextBaseJavaModule implements Activi
         res.putString("cvv", scanResult.cvv);
         res.putString("postalCode", scanResult.postalCode);
         res.putString("cardholderName", scanResult.cardholderName);
+        res.putBoolean("scanned", data.hasExtra(CardIOActivity.EXTRA_CAPTURED_CARD_IMAGE));
         promise.resolve(res);
       } else {
         promise.reject("user_cancelled", "The user cancelled");


### PR DESCRIPTION
### What this PR is about?
This PR adds missed `scanned` functionality into Android RN module.
This is means `scanCard` method would be resolved with `scanned: boolean` field.
It was implemented just for iOS only before.

### List of changes
- while preparing Android `Intent` for presenting `CardIOActivity` the `CardIOActivity.EXTRA_RETURN_CARD_IMAGE` with value `true` was added to request return card image in `onActivityResult` within `Intent data`
- check for `CardIOActivity.EXTRA_CAPTURED_CARD_IMAGE` in `onActivityResult` from received `Intent data` to understand whether this card was scanned or fully entered manually
- readme update (removed `"iOS only"` labels from the `scanned` field)

### Additional notes
The idea of providing this feature for Android was taken from [this native Android SDK issue](https://github.com/card-io/card.io-Android-SDK/issues/111#issuecomment-177754206). Ideally it should be determined using this [`EXTRA_MANUAL_ENTRY_RESULT`](https://github.com/card-io/card.io-Android-source/blob/master/card.io/src/main/java/io/card/payment/CardIOActivity.java#L120) extra value, but unfortunately this thing is private I don't have an access to change this, since this `react-native-awesome-card-io` packages calls the binary under the hood and it's not possible to modify or patch it AFAIK.